### PR TITLE
Clean up and bug fixes

### DIFF
--- a/ISMCTS.py
+++ b/ISMCTS.py
@@ -44,7 +44,7 @@ class LuckAdjuster:
 
         Computes:
 
-        Phi(H) = union_{p' in N(H)} phi(p')
+        Phi(p) = union_{p' in N(p)} phi(p')
 
         where
 
@@ -53,7 +53,7 @@ class LuckAdjuster:
         Q_right = Q[:, 1]
         phi(p') = union_{Q_left <= q <= Q_right} (q[c] - sum_i p'[i] * q[i])
 
-        Returns the set Phi(H) as an Interval.
+        Returns the set Phi(p) as an Interval.
         """
         one_c = np.zeros_like(p)
         one_c[c] = 1

--- a/ISMCTS.py
+++ b/ISMCTS.py
@@ -14,7 +14,6 @@ c_PUCT = 1.0
 
 CHEAT = True  # evaluate model for child nodes immediately, so we don't need Vc
 
-tree_ids = []
 
 def to_interval(i: IntervalLike) -> Interval:
     if isinstance(i, Interval):
@@ -393,6 +392,8 @@ class SamplingNode(Node):
 
 
 class Tree:
+    next_id = 0
+
     def __init__(self, model: Model, root: ActionNode, eps=EPS):
         self.model = model
         self.root = root
@@ -401,22 +402,22 @@ class Tree:
         self.eps = eps
         self.root.eps = eps
 
-        if id(self) not in tree_ids:
-            tree_ids.append(id(self))
+        self.tree_id = Tree.next_id
+        Tree.next_id += 1
 
     def __str__(self):
-        return f'Tree(owner={self.tree_owner}, root={self.root})'
+        return f'Tree(id={self.tree_id}, owner={self.tree_owner}, root={self.root})'
 
     def get_visit_distribution(self, n: int) -> Dict[Action, float]:
         while self.root.N <= n:
-            logging.debug(f'\n======= visit tree: {tree_ids.index(id(self))}, owner: {self.tree_owner} N: {self.root.N}, root: {self.root} id: {id(self)}')
+            logging.debug(f'\n======= visit tree: {self}')
             self.root.visit(self.model)
 
         n_total = self.root.N - 1
         return {action: node.N / n_total for action, node in self.root.children.items()}
 
     def get_spawned_tree_action(self) -> ActionDistribution:
-        logging.debug(f'\n======= get action from spawn tree: {tree_ids.index(id(self))}, owner: {self.tree_owner} N: {self.root.N}, root: {self.root}, id: {id(self)} ')
+        logging.debug(f'\n======= get action from spawn tree: {self}')
 
         while self.root.N < 1:
             self.root.visit(self.model)

--- a/ISMCTS.py
+++ b/ISMCTS.py
@@ -251,13 +251,15 @@ class ActionNode(Node):
 
         logging.debug(f'======= spawned tree action: {action}, root: {self.spawned_tree.root}')
 
+        Qc = np.array([edge.node.Q for edge in self.children.values()])
+
         edge = self.children[action]
         c = edge.index
         child = edge.node
+
         result = child.visit(model)
         child_Q = result.Q
 
-        Qc = np.array([edge.node.Q for edge in self.children.values()])
         luck_adjusted_Q = LuckAdjuster.calc_luck_adjusted_Q(Qc, child_Q, c, action_distr)
 
         old_Q = self.Q
@@ -384,14 +386,16 @@ class SamplingNode(Node):
 
         logging.debug(f'- sampling hidden state {h} from {self.H}')
 
+        Qc = np.array([edge.node.Q for edge in self.children.values()])
+
         edge = self.children[h]
         c = edge.index
         child = edge.node
+
         result = child.visit(model)
         Q_h = result.Q
 
         h_keys = np.array(list(self.children.keys()))
-        Qc = np.array([edge.node.Q for edge in self.children.values()])
         luck_adjusted_Q = LuckAdjuster.calc_luck_adjusted_Q(Qc, Q_h, c, self.H[h_keys])
 
         old_Q = self.Q

--- a/ISMCTS.py
+++ b/ISMCTS.py
@@ -263,7 +263,7 @@ class ActionNode(Node):
         luck_adjusted_Q = LuckAdjuster.calc_luck_adjusted_Q(Qc, child_Q, c, action_distr)
 
         old_Q = self.Q
-        self.Q = self.Q * (self.N - 1) / self.N + luck_adjusted_Q / self.N
+        self.Q = (self.Q * (self.N - 1) + luck_adjusted_Q) / self.N
 
         logging.debug(f'- child_Q: {child_Q}, luck_adjusted: {luck_adjusted_Q}')
         logging.debug(f'- update Q to {self.Q} from {old_Q}')
@@ -399,7 +399,7 @@ class SamplingNode(Node):
         luck_adjusted_Q = LuckAdjuster.calc_luck_adjusted_Q(Qc, Q_h, c, self.H[h_keys])
 
         old_Q = self.Q
-        self.Q = self.Q * (self.N - 1) / self.N + luck_adjusted_Q / self.N
+        self.Q = (self.Q * (self.N - 1) + luck_adjusted_Q) / self.N
 
         logging.debug(f'- Q_h: {Q_h}, luck_adjusted: {luck_adjusted_Q}')
         logging.debug(f'- update Q to {self.Q} from {old_Q}')

--- a/ISMCTS.py
+++ b/ISMCTS.py
@@ -252,6 +252,8 @@ class ActionNode(Node):
 
     def spawned_visit(self, model: Model) -> VisitResult:
         logging.debug(f'\n======= get action distr from spawn tree: {self.spawned_tree}')
+        if self.spawned_tree.root.N == 0:
+            self.spawned_tree.root.visit(model)
         result = self.spawned_tree.root.visit(model)
         action_distr = result.action_distr
         action = np.random.choice(len(self.P), p=action_distr)

--- a/ISMCTS.py
+++ b/ISMCTS.py
@@ -168,7 +168,7 @@ class ActionNode(Node):
         self._expanded = False
 
     def __str__(self):
-        return f'Action({self.info_set}, tree_owner={self.tree_owner}, N={self.N}, Q={self.Q}), V={self.V}'
+        return f'Action({self.info_set}, tree_owner={self.tree_owner}, N={self.N}, Q={self.Q}, V={self.V})'
 
     def eval_model(self, model: Model):
         if self.P is not None or self.terminal():
@@ -252,7 +252,7 @@ class ActionNode(Node):
             return self.unspawned_visit(model)
 
     def spawned_visit(self, model: Model) -> VisitResult:
-        logging.debug(f'\n======= get action distr from spawn tree: {self.spawned_tree}')
+        logging.debug(f'======= get action distr from spawn tree: {self.spawned_tree}')
         if self.spawned_tree.root.N == 0:
             self.spawned_tree.root.visit(model)
         result = self.spawned_tree.root.visit(model)
@@ -436,7 +436,7 @@ class Tree:
 
     def get_visit_distribution(self, n: int) -> Dict[Action, float]:
         while self.root.N <= n:
-            logging.debug(f'\n======= visit tree: {self}')
+            logging.debug(f'======= visit tree: {self}')
             self.root.visit(self.model)
 
         n_total = self.root.N - 1

--- a/ISMCTS.py
+++ b/ISMCTS.py
@@ -246,7 +246,9 @@ class ActionNode(Node):
             return self.unspawned_visit(model)
 
     def spawned_visit(self, model: Model) -> VisitResult:
-        action_distr = self.spawned_tree.get_spawned_tree_action_distr()
+        logging.debug(f'\n======= get action distr from spawn tree: {self.spawned_tree}')
+        result = self.spawned_tree.root.visit(model)
+        action_distr = result.action_distr
         action = np.random.choice(len(self.P), p=action_distr)
 
         logging.debug(f'======= spawned tree action: {action}, root: {self.spawned_tree.root}')
@@ -429,12 +431,3 @@ class Tree:
 
         n_total = self.root.N - 1
         return {action: edge.node.N / n_total for action, edge in self.root.children.items()}
-
-    def get_spawned_tree_action_distr(self) -> ActionDistribution:
-        logging.debug(f'\n======= get action distr from spawn tree: {self}')
-
-        while self.root.N < 1:
-            self.root.visit(self.model)
-
-        result = self.root.visit(self.model)
-        return result.action_distr

--- a/KuhnPoker.py
+++ b/KuhnPoker.py
@@ -181,6 +181,7 @@ if __name__ == '__main__':
     parser.add_argument("--player", type=str, help="Alice or Bob")
     parser.add_argument("--iter", type=int, help="Number of iterations")
     parser.add_argument("--eps", type=float, help="Range parameter for Q-value uncertainty")
+    parser.add_argument("--seed", type=int, help="Random seed")
     args = parser.parse_args()
 
     logging.basicConfig(
@@ -192,6 +193,9 @@ if __name__ == '__main__':
 
     if args.eps is not None:
         Constants.EPS = args.eps
+
+    if args.seed is not None:
+        np.random.seed(args.seed)
 
     if args.player == 'Alice':
         info_set = KuhnPokerInfoSet([PASS, ADD_CHIP], [Card.QUEEN, None])

--- a/KuhnPoker.py
+++ b/KuhnPoker.py
@@ -1,5 +1,5 @@
 from basic_types import Action, HiddenArray, HiddenValue, PolicyArray, Value, ValueChildArray
-from ISMCTS import ActionNode, Tree
+from ISMCTS import ActionNode, Constants, Tree
 from info_set import InfoSet
 from model import Model
 
@@ -190,6 +190,9 @@ if __name__ == '__main__':
         filemode='w'
     )
 
+    if args.eps is not None:
+        Constants.EPS = args.eps
+
     if args.player == 'Alice':
         info_set = KuhnPokerInfoSet([PASS, ADD_CHIP], [Card.QUEEN, None])
     elif args.player == 'Bob':
@@ -199,6 +202,6 @@ if __name__ == '__main__':
 
     model = KuhnPokerModel(1/3, 1/3)
     root = ActionNode(info_set)
-    mcts = Tree(model, root, eps=args.eps)
+    mcts = Tree(model, root)
     visit_dist = mcts.get_visit_distribution(args.iter)
     print(visit_dist)

--- a/KuhnPoker.py
+++ b/KuhnPoker.py
@@ -185,7 +185,7 @@ if __name__ == '__main__':
 
     logging.basicConfig(
         level=logging.DEBUG if args.debug else logging.INFO,
-        format="%(levelname)s - %(asctime)s: %(message)s",
+        format="%(message)s",
         filename="kuhn_poker.log",
         filemode='w'
     )

--- a/basic_types.py
+++ b/basic_types.py
@@ -10,3 +10,4 @@ Interval = np.ndarray  # shape of (2,)
 IntervalLike = Interval | float
 HiddenValue = int
 Action = int
+ActionDistribution = np.ndarray


### PR DESCRIPTION
Three main bug fixes:

1. Backpropagate (luck-adjusted) leaf-Q, rather than child-Q
2. Get child-Q values for luck-adjustment _before_ visiting child, rather than _after_
3. Don't compute action-distr luck-adjustment for pure-actions

Accompanying these fixes are many code cleanup improvements.